### PR TITLE
Fixup CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,14 @@
 #
 # std::experimental::io
 #
+#   Copyright Dalton M. Woodard 2019
+#
+#   Use, modification and distribution is subject to the Boost Software
+#   License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+#   http://www.boost.org/LICENSE_1_0.txt)
+#
+# https://github.com/experimental-io/experimental-io
+#
 cmake_minimum_required(VERSION 3.13)
 
 include(FetchContent)
@@ -9,21 +17,25 @@ project(experimental-io CXX)
 
 # check if xio is a subproject
 if(CMAKE_CURRENT_LIST_DIR STREQUAL CMAKE_SOURCE_DIR)
-    set(NOT_SUBPROJECT ON)
+    set(XIO_NOT_SUBPROJECT ON)
 endif()
 
 option(XIO_WERROR "Use -Werror compiler flag" ON)
+option(XIO_BUILD_TESTING "Build xio tests" ON)
 
 # required cmcstl2 dependency
 find_package(cmcstl2 CONFIG QUIET)
 if(NOT cmcstl2_FOUND)
     FetchContent_Declare(
         cmcstl2
-        GIT_REPOSITORY https://github.com/CaseyCarter/cmcstl2.git
+        GIT_REPOSITORY https://github.com/daltonwoodard/cmcstl2.git
+        GIT_TAG cmake-adjustment-for-subproject
     )
     FetchContent_GetProperties(cmcstl2)
     if(NOT cmcstl2_POPULATED)
         FetchContent_Populate(cmcstl2)
+        set(STL2_BUILD_EXAMPLES OFF CACHE BOOL "")
+        set(STL2_BUILD_TESTING OFF CACHE BOOL "")
         add_subdirectory(${cmcstl2_SOURCE_DIR} ${cmcstl2_BINARY_DIR})
     endif()
 endif()
@@ -31,8 +43,8 @@ endif()
 add_library(xio INTERFACE)
 target_link_libraries(xio INTERFACE stl2)
 target_include_directories(xio INTERFACE
-    $<BUILD_INTERFACE:/include>
-    $<INSTALL_INTERFACE:/include>)
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)
 target_compile_features(xio INTERFACE cxx_std_17)
 target_compile_options(xio INTERFACE
     $<$<CXX_COMPILER_ID:GNU>:-fconcepts>
@@ -48,7 +60,8 @@ install(FILES ${PROJECT_BINARY_DIR}/experimental-io-config.cmake
 
 # only enable the test suite if xio is being built as a standalone project
 # or a test build is requested
-if(NOT_SUBPROJECT OR BUILD_TESTING)
+if(XIO_NOT_SUBPROJECT OR XIO_BUILD_TESTING)
     include(CTest)
+    add_custom_target(xio-check ${CMAKE_CTEST_COMMAND} -V)
     add_subdirectory(test)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,14 @@
 #
 # std::experimental::io
 #
-
+#   Copyright Dalton M. Woodard 2019
+#
+#   Use, modification and distribution is subject to the Boost Software
+#   License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+#   http://www.boost.org/LICENSE_1_0.txt)
+#
+# https://github.com/experimental-io/experimental-io
+#
 add_library(xio-test-config INTERFACE)
 
 target_link_libraries(xio-test-config INTERFACE xio)
@@ -11,13 +18,13 @@ target_compile_options(xio-test-config INTERFACE
   -march=native -ftemplate-backtrace-limit=0
   $<$<CXX_COMPILER_ID:GNU>:
     -Wall -Wextra
-    -Wconversion -Wold-style-cast -Wfloat-equal
-    -Wlogical-op -Wundef -Wredundant-decls
-    -Wshadow -Wwrite-strings -Wpointer-arith
+    -Wconversion -Wfloat-equal
+    -Wlogical-op -Wredundant-decls
+    -Wwrite-strings -Wpointer-arith
     -Wformat=2 -Wswitch-default -Wcast-qual
     -Wcast-align -Wswitch-enum -Wnon-virtual-dtor
     -Wctor-dtor-privacy -Wdisabled-optimization
-    -Winvalid-pch -Wnoexcept -Wmissing-declarations
+    -Winvalid-pch -Wmissing-declarations
     -Woverloaded-virtual -Wdouble-promotion
     -Wtrampolines -Wzero-as-null-pointer-constant
     -Wuseless-cast -Wvector-operation-performance
@@ -49,6 +56,9 @@ if(NOT Catch2_FOUND)
     FetchContent_GetProperties(catch2)
     if(NOT catch2_POPULATED)
         FetchContent_Populate(catch2)
+        set(CATCH_BUILD_TESTING OFF CACHE BOOL "")
+        set(CATCH_INSTALL_DOCS OFF CACHE BOOL "")
+        set(CATCH_INSTALL_HELPERS OFF CACHE BOOL "")
         add_subdirectory(${catch2_SOURCE_DIR} ${catch2_BINARY_DIR})
     endif()
 endif()
@@ -56,7 +66,8 @@ endif()
 function(add_xio_test TESTNAME EXENAME FIRSTSOURCE)
   add_executable(${EXENAME} ${FIRSTSOURCE} ${ARGN})
   target_link_libraries(${EXENAME} xio-test-config Catch2::Catch2)
-  add_test(${TESTNAME} ${EXENAME})
+  add_test(NAME ${TESTNAME} COMMAND $<TARGET_FILE:${EXENAME}>)
+  add_dependencies(xio-check ${EXENAME})
 endfunction()
 
-add_xio_test(empty empty empty-test.cpp)
+add_xio_test(test.empty empty empty-test.cpp)


### PR DESCRIPTION
@slurps-mad-rips I got everything to play together nicely in out-of-tree builds. I opened up another PR in cmcstl2 with the changes to get that working: https://github.com/CaseyCarter/cmcstl2/pull/279. I probably didn't address most of the things you mentioned wanting to change though.

@eliaskosunen I had to remove some of the GCC warnings that cmcstl2 doesn't compile cleanly with for the time being.